### PR TITLE
:bug: Fix [#60] 에러 응답 포맷 및 result 필드 일관성 수정

### DIFF
--- a/src/main/java/com/cook/cookapp/apiPayload/code/exception/ExceptionAdvice.java
+++ b/src/main/java/com/cook/cookapp/apiPayload/code/exception/ExceptionAdvice.java
@@ -70,13 +70,13 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     private ResponseEntity<Object> handleDetailedException(Exception e, ErrorReasonDTO reason,
                                                            HttpServletRequest request) {
-        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), reason.getMessage());
         WebRequest webRequest = new ServletWebRequest(request);
         return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, reason.getHttpStatus(), webRequest);
     }
 
     private ResponseEntity<Object> handleSimpleException(Exception e, ErrorStatus errorStatus, WebRequest request) {
-        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), e.getMessage());
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorStatus.getMessage());
         return super.handleExceptionInternal(e, body, HttpHeaders.EMPTY, errorStatus.getHttpStatus(), request);
     }
 

--- a/src/main/java/com/cook/cookapp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cook/cookapp/common/security/JwtAuthenticationFilter.java
@@ -50,10 +50,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         response.setStatus(errorCode.getHttpStatus().value());
         ObjectMapper objectMapper = new ObjectMapper();
 
-        ApiResponse<String> failureResponse = ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(),null);
+        ApiResponse<String> failureResponse = ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(),errorCode.getMessage());
         String s = objectMapper.writeValueAsString(failureResponse);
 
         response.getWriter().write(s);
-        ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(),null);
     }
 }

--- a/src/main/java/com/cook/cookapp/user/controller/KakaoLoginController.java
+++ b/src/main/java/com/cook/cookapp/user/controller/KakaoLoginController.java
@@ -42,11 +42,12 @@ public class KakaoLoginController {
 
     @Operation(summary = "로그인한 유저 id 확인하기", description = "test용")
     @PostMapping("whoami")
-    public Long whoami() {
+    public ApiResponse<Long> whoami() {
         Long userIdFromToken = jwtTokenProvider.getUserIdFromToken();
 
-        User user = userRepository.findById(userIdFromToken).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        //회원가입, 로그인 동시진행
-        return user.getId();
+        User user = userRepository.findById(userIdFromToken)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        return ApiResponse.onSuccess(user.getId());
     }
 }


### PR DESCRIPTION
## 🔍 이슈 번호
[#60]
## ✨ PR 요약
<!--변경 포인트-->
- [x] ExceptionAdvice, JwtAuthenticationFilter 수정
- [x] 모든 에러 응답 result 필드에 메시지 포함되도록 통일
- [x] KakaoLoginController의 whoami 응답 포맷 표준화
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- [x] ExceptionAdvice 수정: GeneralException 및 기타 예외 시 result 필드에 항상 메시지 포함
- [x] JwtAuthenticationFilter 수정: 인증 실패 시에도 result 필드에 메시지 포함
- [x] KakaoLoginController의 whoami 응답도 ApiResponse 포맷으로 일관화

---