### PR TITLE
:sparkles: Feat [#79] JWT 토큰 관리 Redis 전환 및 TTL 설정 적용(로컬)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
 
 	//Thymeleaf
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	//Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
@@ -18,6 +18,8 @@ public enum ErrorStatus implements BaseErrorCode {
     JWT_EMPTY(HttpStatus.UNAUTHORIZED, "JWT4003", "JWT 토큰을 넣어주세요."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "JWT4004", "만료된 토큰입니다."),
     JWT_REFRESHTOKEN_NOT_MATCHED(HttpStatus.UNAUTHORIZED, "JWT4005", "RefreshToken이 일치하지 않습니다."),
+    JWT_REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT4031", "리프레시 토큰이 존재하지 않거나 만료되었습니다."),
+    JWT_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "JWT4032", "유효하지 않은 리프레시 토큰입니다."),
 
     // 가장 일반적인 응답
     _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),

--- a/src/main/java/com/cook/cookapp/common/RedisCacheConfig.java
+++ b/src/main/java/com/cook/cookapp/common/RedisCacheConfig.java
@@ -1,0 +1,31 @@
+package com.cook.cookapp.common;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching // Spring Boot의 캐싱 설정을 활성화, @Cacheable 등을 쓸 수 있게 해줌
+public class RedisCacheConfig {
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration
+                .defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)))
+                .entryTtl(Duration.ofMinutes(1L)); // 필요에 따라 TTL 조정
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+}

--- a/src/main/java/com/cook/cookapp/common/RedisConfig.java
+++ b/src/main/java/com/cook/cookapp/common/RedisConfig.java
@@ -1,0 +1,50 @@
+package com.cook.cookapp.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisPassword;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.password}")
+    private String password;
+
+    /**
+     * JWT 전용 RedisTemplate 설정
+     * Redis 0번 DB를 사용하여 리프레시 토큰, 블랙리스트 토큰 등을 관리
+     */
+    @Bean(name = "jwtRedisTemplate")
+    public RedisTemplate<String, Object> jwtRedisTemplate() {
+        // 0번 DB 설정
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
+        config.setPassword(RedisPassword.of(password));
+        config.setDatabase(0); // 0번 DB 사용
+
+        // Lettuce 연결
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+
+        // RedisTemplate 생성 및 직렬화 설정
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/cook/cookapp/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/cook/cookapp/common/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
 package com.cook.cookapp.common.security;
 
-
 import com.cook.cookapp.apiPayload.ApiResponse;
 import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,13 +11,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
 
+//HTTP 요청 시 들어온 JWT 토큰을 검증하여 인증 처리 및 SecurityContext 에 인증 정보 저장
 @Slf4j
 @RequiredArgsConstructor
 @Component
@@ -28,31 +26,35 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
-        // 헤더에서 JWT 를 받아옵니다.
         HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String token = jwtTokenProvider.resolveAccessToken(); // 요청 헤더에서 액세스 토큰 추출 (Bearer 제거 후 토큰 추출)
+        log.info("JwtAuthenticationFilter 토큰: {}", token);
 
-        // 요청 헤더에서 JWT 를 받아옵니다.
-        log.info("dofilter 토큰 : " + jwtTokenProvider.resolveAccessToken());
-        String token = jwtTokenProvider.resolveAccessToken();
-        log.info("token : " + token);
-
-
-        // 유효한 토큰인지 확인.
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(token);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+    // 간결하게 인증 처리: 토큰 유효성 검증 + 블랙리스트 확인 + 인증 정보 주입
+        if (jwtTokenProvider.processTokenAndSetAuthContext(token)) {
+            // 인증 성공 시 SecurityContext에 등록 완료
+        } else if (token != null) { // 유효하지 않거나 블랙리스트에 있을 경우 예외 응답 처리
+            log.warn("무효화된 토큰이거나 잘못된 토큰입니다.");
+            setErrorResponse((HttpServletResponse) response, ErrorStatus.JWT_INVALID);
+            return;
         }
-        filterChain.doFilter(request, response);
+
+        filterChain.doFilter(request, response); // 다음 필터 또는 컨트롤러로 요청 전달
     }
 
+    // 오류 응답 포맷 지정
     public static void setErrorResponse(HttpServletResponse response, ErrorStatus errorCode) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(errorCode.getHttpStatus().value());
         ObjectMapper objectMapper = new ObjectMapper();
 
-        ApiResponse<String> failureResponse = ApiResponse.onFailure(errorCode.getCode(),errorCode.getMessage(),errorCode.getMessage());
-        String s = objectMapper.writeValueAsString(failureResponse);
+        ApiResponse<String> failureResponse = ApiResponse.onFailure(
+                errorCode.getCode(),
+                errorCode.getMessage(),
+                errorCode.getMessage()
+        );
 
-        response.getWriter().write(s);
+        String json = objectMapper.writeValueAsString(failureResponse);
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/com/cook/cookapp/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/cook/cookapp/common/security/JwtTokenProvider.java
@@ -1,14 +1,13 @@
 package com.cook.cookapp.common.security;
 
-
-import com.cook.cookapp.apiPayload.code.exception.GeneralException;
-import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
 import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,8 +18,9 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.Base64;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -28,132 +28,91 @@ import java.util.concurrent.ConcurrentHashMap;
 public class JwtTokenProvider {
 
     @Value("${jwt.secret}")
-    private String stringSecretKey;  // String 형식보다는 Key 형식이 안전
+    private String stringSecretKey;
 
     private Key secretKey;
 
-    // 블랙리스트 (로그아웃된 토큰 저장) - 간단한 구현 (Redis 사용 가능)
-    private final Set<String> invalidatedTokens = Collections.newSetFromMap(new ConcurrentHashMap<>());
-
-    // 저장된 리프레시 토큰 목록 (실제 환경에서는 Redis 사용 권장)
-    private final Map<Long, String> refreshTokenStore = new HashMap<>();
-
-    // 토큰의 유효시간
-//    public static final long TOKEN_VALID_TIME = 1000L * 60 * 5; // Access 토큰 5분(밀리초)
-    public static final long TOKEN_VALID_TIME = 1000L * 60 * 60;    // Access 토큰 1시간(밀리초) - 임시
-    public static final long REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 7;   // 일주일(밀리초)
-    public static final int REFRESH_TOKEN_VALID_TIME_IN_COOKIE = 60 * 60 * 24 * 7; // 일주일(초)
-    public static final int REFRESH_TOKEN_VALID_TIME_IN_REDIS = 60 * 60 * 24 * 7; // 일주일(초)
+    public static final long TOKEN_VALID_TIME = 1000L * 60 * 60;  // 액세스 토큰 1시간
+    public static final long REFRESH_TOKEN_VALID_TIME = 1000L * 60 * 60 * 24 * 7; // 리프레시 토큰 1주일
 
     private final CustomUserDetailsService userDetailService;
 
-    // 객체 초기화, secretKey 를 Base64 로 인코딩 후 Key 객체로 변환
+    @Qualifier("jwtRedisTemplate")
+    private final RedisTemplate<String, Object> redisTemplate;
+
     @PostConstruct
     protected void init() {
         byte[] keyBytes = Base64.getDecoder().decode(stringSecretKey.getBytes(StandardCharsets.UTF_8));
         secretKey = new SecretKeySpec(keyBytes, SignatureAlgorithm.HS256.getJcaName());
     }
 
-    // Jwt AccessToken 생성
+    // 액세스 토큰 생성
     public String createAccessToken(Long userId) {
         return Jwts.builder()
-                .setHeaderParam("type", "accessToken")
                 .claim("userId", userId)
-                .setIssuedAt(new Date(System.currentTimeMillis()))  // Access 토큰 발행 시간
-                .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME)) // Access 토큰 만료 시간
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + TOKEN_VALID_TIME))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
 
-    // Jwt RefreshToken 생성  & HashMap 저장
+    // 리프레시 토큰 생성 후 Redis에 저장
     public String createRefreshToken(Long userId) {
         String refreshToken = Jwts.builder()
-                .setHeaderParam("type", "refreshToken")
                 .claim("userId", userId)
-                .setIssuedAt(new Date(System.currentTimeMillis()))  // Refresh 토큰 발행 시간
-                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME)) // Refresh 토큰 만료 시간
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + REFRESH_TOKEN_VALID_TIME))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
 
-        // 리프레시 토큰 저장
-        refreshTokenStore.put(userId, refreshToken);
+        redisTemplate.opsForValue().set(
+                "RT:" + userId,
+                refreshToken,
+                REFRESH_TOKEN_VALID_TIME,
+                TimeUnit.MILLISECONDS
+        );
         return refreshToken;
     }
 
-    // HashMap에서 저장된 리프레시 토큰 가져오기
+    // 저장된 리프레시 토큰을 Redis에서 가져오기
     public String getStoredRefreshToken(Long userId) {
-        return refreshTokenStore.get(userId);
-    }
-    // Refresh Token 삭제 (로그아웃 시)
-    public void deleteRefreshToken(Long userId) {
-        refreshTokenStore.remove(userId);
+        return (String) redisTemplate.opsForValue().get("RT:" + userId);
     }
 
-    // 리프레시 토큰 검증
-    public boolean validateRefreshToken(String token, Long userId) {
-        String storedToken = getStoredRefreshToken(userId);
-        if (!token.equals(storedToken)) {
-            log.warn("리프레시 토큰이 일치하지 않습니다.");
-            return false;
-        }
+    // 리프레시 토큰 삭제 (Redis에서 제거)
+    public void deleteRefreshToken(Long userId) {
+        redisTemplate.delete("RT:" + userId);
+    }
+
+    // JWT 토큰의 유효성을 검증
+    public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token);
             return true;
-        } catch (ExpiredJwtException e) {
-            log.warn("리프레시 토큰이 만료되었습니다.");
-        } catch (Exception e) {
-            log.warn("유효하지 않은 리프레시 토큰입니다.");
-        }
-        return false;
-    }
-
-    // 토큰 정보를 검증하는 메서드
-    public boolean validateToken(String token) {
-        if (isTokenInvalidated(token)) {
-            log.warn("무효화된 JWT 토큰입니다: {}", token);
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("JWT validation failed: {}", e.getMessage());
             return false;
         }
-        try {
-            Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(token);
-            return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT Token", e);
-        } catch (ExpiredJwtException e) {
-            log.info("Expired JWT Token", e);
-        } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT Token", e);
-        } catch (IllegalArgumentException e) {
-            log.info("JWT claims string is empty", e);
-        }
-        return false;
     }
 
-    // 로그아웃 시 토큰 블랙리스트에 추가
+    // 리프레시 토큰 유효성 검증 (Redis에 저장된 토큰과 비교)
+    public boolean validateRefreshToken(String token, Long userId) {
+        String storedToken = getStoredRefreshToken(userId);
+        return token.equals(storedToken) && validateToken(token);
+    }
+
+    // 로그아웃 시 토큰을 블랙리스트에 추가하여 무효화
     public void invalidateToken(String token) {
-        // [수정] Bearer 접두사가 붙어 있는 경우 제거
-        if (token != null && token.startsWith("Bearer ")) {
-            token = token.substring(7); // 접두사 제거 후 순수 토큰만 저장
-        }
-
-        log.info("로그아웃: 토큰 무효화 -> {}", token);
-        invalidatedTokens.add(token);
-
-        // [기존 유지] 만료 시점에 맞춰 블랙리스트 자동 제거 스케줄러 실행
-        long expirationTime = getTokenExpiration(token);
-        if (expirationTime > 0) {
-            final String finalToken = token;  // 캡처를 위해 final 변수 사용
-            new Timer().schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    invalidatedTokens.remove(finalToken);
-                    log.info("만료된 토큰 제거 -> {}", finalToken);
-                }
-            }, expirationTime);
-        }
+        long expiration = getTokenExpiration(token);
+        redisTemplate.opsForValue().set("BL:" + token, "logout", expiration, TimeUnit.MILLISECONDS);
     }
+
+    // 토큰이 블랙리스트에 있는지 확인
+    public boolean isTokenInvalidated(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey("BL:" + token));
+    }
+
+    // 토큰의 남은 만료 시간을 계산
     private long getTokenExpiration(String token) {
         try {
             Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
@@ -163,58 +122,57 @@ public class JwtTokenProvider {
         }
     }
 
-    // 토큰 블랙리스트 확인
-    public boolean isTokenInvalidated(String token) {
-        // [수정] 검증 시에도 Bearer 접두사가 붙어 있으면 제거하고 비교
-        if (token != null && token.startsWith("Bearer ")) {
-            token = token.substring(7);
-        }
-
-        return invalidatedTokens.contains(token);
+    // 액세스 토큰에서 사용자 ID 추출
+    public Long getUserIdFromToken() {
+        String accessToken = resolveAccessToken();
+        return getUserIdInToken(accessToken);
     }
 
-    // Request 의 Header 에서 token 값을 가져옵니다. "Authorization" : "TOKEN 값"
+    // JWT 토큰에서 사용자 ID를 직접 추출
+    public Long getUserIdInToken(String token) {
+        Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
+        return claims.get("userId", Long.class);
+    }
+
+    // HTTP 요청에서 액세스 토큰 추출 (Bearer 접두사 제거)
     public String resolveAccessToken() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         String token = request.getHeader("Authorization");
         return (token != null && token.startsWith("Bearer ")) ? token.substring(7) : token;
     }
 
+    // HTTP 요청에서 리프레시 토큰 추출 (Bearer 접두사 제거)
     public String resolveRefreshToken() {
         HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
         String token = request.getHeader("Refresh-Token");
         return (token != null && token.startsWith("Bearer ")) ? token.substring(7) : token;
     }
 
-    // UserId 추출
-    public Long getUserIdFromToken() {
-        String accessToken = resolveAccessToken();
-        if (accessToken == null || !validateToken(accessToken)) {
-            throw new GeneralException(ErrorStatus.JWT_INVALID);
-        }
-        return getUserIdInToken(accessToken);
-    }
-
-    // 토큰에서 userId 추출
-    public Long getUserIdInToken(String token) {
-        return extractAllClaims(token).get("userId", Long.class);
-    }
-
-    // 토큰 parsing
-    public Claims extractAllClaims(String jwtToken) {
-        return Jwts.parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
-                .parseClaimsJws(jwtToken)
-                .getBody();
-    }
-
-    // JWT 토큰에서 인증 정보(권한) 조회
+    // 토큰에서 인증 정보 추출하여 Authentication 객체 생성
     public Authentication getAuthentication(String token) {
-        String userId = String.valueOf(getUserIdInToken(token)); //long -> string으로 형변환
-
+        String userId = String.valueOf(getUserIdInToken(token));
         UserDetails userDetails = userDetailService.loadUserByUsername(userId);
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
 
-        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());  // ""은 비밀번호가 들어갈 자리지만 토큰기반 비밀번호 X
+    // JwtAuthenticationFilter 에 적용: 필터 내에서 유효성 검증 후 AuthenticationContext에 저장
+    public boolean processTokenAndSetAuthContext(String token) {
+        if (token != null && validateToken(token) && !isTokenInvalidated(token)) {
+            Authentication authentication = getAuthentication(token);
+            org.springframework.security.core.context.SecurityContextHolder.getContext().setAuthentication(authentication);
+            return true;
+        }
+        return false;
+    }
+
+    // UserServiceImpl 에서 로그아웃 처리 시 사용: 블랙리스트 및 리프레시 토큰 삭제
+    public void handleLogout(String accessToken, String refreshToken) {
+        if (accessToken != null) {
+            invalidateToken(accessToken);
+        }
+        if (refreshToken != null) {
+            Long userId = getUserIdInToken(refreshToken);
+            deleteRefreshToken(userId);
+        }
     }
 }

--- a/src/main/java/com/cook/cookapp/user/controller/UserController.java
+++ b/src/main/java/com/cook/cookapp/user/controller/UserController.java
@@ -75,13 +75,8 @@ public class UserController {
             return ApiResponse.onFailRefresh();
         }
 
-        // 기존 RefreshToken 무효화 (삭제)
-        jwtTokenProvider.deleteRefreshToken(userId);
-
-        // 기존 AccessToken 블랙리스트 처리 추가
-        if (accessToken != null) {
-            jwtTokenProvider.invalidateToken(accessToken);
-        }
+        //  헬퍼 메서드로 로그아웃 처리 간소화
+        jwtTokenProvider.handleLogout(accessToken, refreshToken);
 
         // 새로운 액세스 토큰 & 리프레시 토큰 발급
         String newAccessToken = jwtTokenProvider.createAccessToken(userId);

--- a/src/main/java/com/cook/cookapp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/user/service/UserServiceImpl.java
@@ -18,18 +18,17 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
+
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
 
+    // 일반 로그인 처리: 이메일로 유저 찾고 토큰 발급
     public UserDtoRes.UserLoginRes login(HttpServletRequest request, HttpServletResponse response, UserDtoReq.LoginReq loginDto) {
-
         String email = loginDto.getEmail();
 
         User user = userRepository.findByEmail(email)
@@ -38,27 +37,20 @@ public class UserServiceImpl implements UserService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
-        log.info("login refresh token : {}", refreshToken);
+        log.info("[로그인 완료] 발급된 리프레시 토큰: {}", refreshToken);
 
         return UserConverter.signInRes(user, accessToken, refreshToken, user.getNickname());
     }
+
+    // 로그아웃 처리: 액세스 토큰 블랙리스트 추가 및 리프레시 토큰 삭제
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, String accessToken) {
-        if (accessToken != null) {
-            jwtTokenProvider.invalidateToken(accessToken); // 액세스 토큰을 블랙리스트에 추가
-        }
-
-        // 리프레시 토큰 삭제 (AccessToken이 만료된 경우 대비)
         String refreshToken = jwtTokenProvider.resolveRefreshToken();
-        if (refreshToken != null) {
-            Long userId = jwtTokenProvider.getUserIdInToken(refreshToken); // RefreshToken을 활용해 UserId 가져오기
-            jwtTokenProvider.deleteRefreshToken(userId);
-        }
+        jwtTokenProvider.handleLogout(accessToken, refreshToken);
     }
 
+    // 카카오 로그인 시 신규 회원가입 또는 기존 회원 조회
     public User kakaoSignup(KakaoUserInfoResponseDto userInfo) {
-        //이미 회원가입한 이메일이 있다면 user 리턴
-        //회원가입된게 없다면 회원가입 및 유저프로필 생성 후 유저 리턴
         return userRepository.findByEmail(userInfo.getKakaoAccount().getEmail())
                 .orElseGet(() -> {
                     User newUser = User.builder()
@@ -66,37 +58,38 @@ public class UserServiceImpl implements UserService {
                             .name(userInfo.getKakaoAccount().getProfile().getNickname())
                             .build();
                     userRepository.save(newUser);
-
                     return newUser;
                 });
     }
 
+    // 카카오 로그인 처리 후 토큰 발급
     public UserDtoRes.UserLoginRes kakaoLogin(HttpServletRequest request, HttpServletResponse response, User user) {
-
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
-        log.info("login refresh token : {}", refreshToken);
+        log.info("[카카오 로그인] 발급된 리프레시 토큰: {}", refreshToken);
 
         return UserConverter.signInRes(user, accessToken, refreshToken, user.getNickname());
     }
 
-    public boolean duplicateNickname(String nickname){
-        boolean exists = userRepository.existsByNickname(nickname);
-        return exists;
+    // 닉네임 중복 검사
+    public boolean duplicateNickname(String nickname) {
+        return userRepository.existsByNickname(nickname);
     }
 
-    public User getUserByNickname(String nickname){
-        User user = userRepository.findByNickname(nickname)
+    // 닉네임으로 유저 조회
+    public User getUserByNickname(String nickname) {
+        return userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        return user;
     }
 
-    public User getUserById(Long id){
-        Optional<User> user = userRepository.findById(id);
-        return user.orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    // ID로 유저 조회
+    public User getUserById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
     }
 
+    // 사용자 프로필 조회 (ID 기준)
     public UserDtoRes.UserProfileRes getUserProfileById(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -104,26 +97,25 @@ public class UserServiceImpl implements UserService {
         return UserConverter.userProfileRes(user);
     }
 
+    // 사용자 프로필 조회 (닉네임 기준)
     public UserDtoRes.UserProfileRes getUserProfileByNickname(String nickname) {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
         return UserConverter.userProfileRes(user);
     }
 
-    // 취향 업데이트
+    // 음식 취향 업데이트 (입력값 검증 포함)
     public void updateTastePreference(Long userId, UserDtoReq.TastePreferenceRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        // 필터 검증 실행
         TastePreferenceValidator.validateTastePreference(request.getTastePreference());
-
-        // 검증 후 저장
         user.setTastePreference(request.getTastePreference());
         userRepository.save(user);
     }
 
-    // 취향 조회
+    // 저장된 음식 취향 가져오기
     public String getTastePreference(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
@@ -131,13 +123,11 @@ public class UserServiceImpl implements UserService {
         return user.getTastePreference() != null ? user.getTastePreference() : "";
     }
 
-    public void addNickname(Long userId, String nickname){
-        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+    // 닉네임 추가 및 저장
+    public void addNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         user.setNickname(nickname);
         userRepository.save(user);
     }
-
-
 }
-
-

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,15 +19,21 @@ spring:
     properties:
       hibernate.format_sql: true
       dialect: org.hibernate.dialect.MySQL8InnoDBDialect
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      password: 4014
+
+logging:
+  level:
+    org.hibernate.SQL: debug
+    org.springframework.cache: trace # Redis
 
   security:
     user:
       name: user
       password: password
-
-logging:
-  level:
-    org.hibernate.SQL: debug
 
 file:
   upload-dir: upload


### PR DESCRIPTION
## 🔍 이슈 번호
[#79]
## ✨ PR 요약
<!--변경 포인트-->
- [x] JWT 토큰 Redis 관리 적용
- [x] 인증/로그아웃 처리 헬퍼 메서드 도입
- [x] 인증 필터 로직 간결화
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- [x] Redis 0번 DB를 JWT 전용으로 설정 (jwtRedisTemplate)
- [x] 리프레시 토큰/블랙리스트 Redis 저장 처리
- [x] handleLogout, processTokenAndSetAuthContext 메서드 도입
- [x] 필터와 컨트롤러 내 인증/로그아웃 처리 코드 간소화
---