### PR TITLE
:sparkles: Feat[#112] 레시피 삭제/수정,이미지 업로드 API 구현

### DIFF
--- a/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
@@ -56,10 +56,14 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_LIKED_RECIPE(HttpStatus.BAD_REQUEST, "RECIPE4000", "레시피에 이미 좋아요를 눌렀습니다"),
     NOT_LIKED_YET(HttpStatus.BAD_REQUEST, "RECIPE4000","레시피에 좋아요를 누르지 않았습니다"),
     UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "RECIPE4001","레시피의 소유자가 아닙니다"),
+    INVALID_RECIPE_FORMAT(HttpStatus.BAD_REQUEST,"RECIPE4000" , "레시피 형식이 잘못됐습니다" ),
 
     //Chatbot
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "400", "유효하지 않은 입력 값입니다."),
     OPENAI_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI500", "AI 추천 서비스 호출 중 오류가 발생했습니다."),
+
+    //Image
+    INVALID_IMAGE_URL(HttpStatus.NOT_FOUND,"RECIPE4004","이미지 URL을 찾을 수 없습니다"),
 
     //ProfileImage
     FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "FILE4000", "이미지 용량은 5MB이하로 해주세요"),

--- a/src/main/java/com/cook/cookapp/common/RedisConfig.java
+++ b/src/main/java/com/cook/cookapp/common/RedisConfig.java
@@ -19,8 +19,8 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
-//    @Value("${spring.data.redis.password}")
-//    private String password;
+    @Value("${spring.data.redis.password}")
+    private String password;
 
     /**
      * JWT 전용 RedisTemplate 설정
@@ -30,7 +30,7 @@ public class RedisConfig {
     public RedisTemplate<String, Object> jwtRedisTemplate() {
         // 0번 DB 설정
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(host, port);
-//        config.setPassword(RedisPassword.of(password));
+        config.setPassword(RedisPassword.of(password));
         config.setDatabase(0); // 0번 DB 사용
 
         // Lettuce 연결

--- a/src/main/java/com/cook/cookapp/global/util/AmazonS3Util.java
+++ b/src/main/java/com/cook/cookapp/global/util/AmazonS3Util.java
@@ -5,6 +5,10 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.cook.cookapp.apiPayload.code.exception.GeneralException;
 import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
 import com.cook.cookapp.post.repository.PostRepository;
+import com.cook.cookapp.recipe.entity.Recipe;
+import com.cook.cookapp.recipe.entity.RecipeImage;
+import com.cook.cookapp.recipe.repository.RecipeImageRepository;
+import com.cook.cookapp.recipe.repository.RecipeRepository;
 import com.cook.cookapp.user.entity.ProfileImage;
 import com.cook.cookapp.user.entity.User;
 import com.cook.cookapp.user.repository.ProfileImageRepository;
@@ -19,6 +23,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 @Slf4j
@@ -32,6 +41,8 @@ public class AmazonS3Util {
     private final UserRepository userRepository;
     private final PostRepository postRepository;
     final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+    private final RecipeImageRepository recipeImageRepository;
+    private final RecipeRepository recipeRepository;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -39,9 +50,14 @@ public class AmazonS3Util {
     @Value("${cloud.aws.s3.path.profile}")
     private String profilePath;
 
+    @Value("${cloud.aws.s3.path.recipe}")
+    private String recipePath;
+
 //    @Value("${cloud.aws.s3.path.post}")
 //    private String postPath;
 
+    //프로필 이미지 업로드
+    //db에 있는걸 먼저 찾고 s3를 삭제한 후 디비 데이터를 삭제해주시면 됩니다!
     @Transactional
     public String profileImageUpload(MultipartFile multipartFile, Long userId) throws IOException {
 
@@ -99,6 +115,59 @@ public class AmazonS3Util {
         }
     }
 
+    @Transactional
+    public String recipeImageUpload(MultipartFile multipartFile,Long recipeId, Long userId) throws IOException {
+
+        String contentType = multipartFile.getContentType();
+        //용량 5MB이하만 받도록 제한
+        if(multipartFile.getSize() > MAX_FILE_SIZE) {
+            throw new GeneralException(ErrorStatus.FILE_TOO_LARGE);
+        }
+
+        //이미지 파일만 받도록 제한
+        if(contentType == null || !contentType.startsWith("image/") ){
+            throw new GeneralException(ErrorStatus.INVALID_FILE_TYPE);
+        } else {
+
+            Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
+
+            RecipeImage existingRecipeImage = recipeImageRepository.findByRecipe(recipe);
+
+            // 기존 이미지 삭제
+            if (existingRecipeImage != null) {
+                recipe.setRecipeImage(null);
+                recipeRepository.save(recipe);
+                String existingKey = recipePath + "/" + existingRecipeImage.getUuid() + "_" + existingRecipeImage.getOriginalFilename();
+                amazonS3Client.deleteObject(bucket, existingKey);  // S3에서 삭제
+            }
+
+
+            // 새 이미지 업로드
+            String uuid = UUID.randomUUID().toString();
+            String key = recipePath + "/" + uuid + "_" + multipartFile.getOriginalFilename();
+
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentLength(multipartFile.getSize());
+            metadata.setContentType(multipartFile.getContentType());
+            // S3에 업로드
+            amazonS3Client.putObject(bucket, key, multipartFile.getInputStream(), metadata);
+
+            RecipeImage newRecipeImage = RecipeImage.builder()
+                    .uuid(uuid)
+                    .originalFilename(multipartFile.getOriginalFilename())
+                    .contentType(multipartFile.getContentType())
+                    .fileSize(multipartFile.getSize())
+                    .recipe(recipe)
+                    .build();
+
+            recipe.setRecipeImage(newRecipeImage);
+            recipeRepository.save(recipe);
+            recipeImageRepository.save(newRecipeImage);
+
+            return amazonS3Client.getUrl(bucket, key).toString();
+        }
+    }
+
     //프로필 이미지 url 가져오기
     public String getProfilePath(Long userId) {
         User user = userRepository.findById(userId).orElseThrow(() -> new IllegalArgumentException("해당 유저가 없습니다."));
@@ -107,6 +176,18 @@ public class AmazonS3Util {
             return null;
         }
         return amazonS3.getUrl(bucket, profilePath + "/" + profileImage.getUuid() + "_" + profileImage.getOriginalFilename()).toString();
+    }
+
+    //레시피 이미지 url 가져오기
+    public String getRecipePath(Long recipeId) {
+        Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
+
+        RecipeImage recipeImage = recipeImageRepository.findByRecipe(recipe);
+        if(recipeImage == null){
+            return null;
+        }
+
+        return amazonS3.getUrl(bucket, recipePath + "/" + recipeImage.getUuid() + "_" + recipeImage.getOriginalFilename()).toString();
     }
 
     //    // MultipartFile 을 전달받아 File 로 전환한 후 S3에 업로드
@@ -161,4 +242,32 @@ public class AmazonS3Util {
     public String generateKeyName(String path, ProfileImage profileImage) {
         return profilePath + '/' + profileImage.getUuid();
     }
+
+    public void deleteRecipeImage(String imageUrl) {
+        // URL에서 S3 Key 추출
+        String fileKey = extractFileKeyFromUrl(imageUrl);
+
+        try {
+            // 한글이 포함된 경우 URL 디코딩 적용 (예외 처리 추가)
+            fileKey = URLDecoder.decode(fileKey, StandardCharsets.UTF_8.name());
+            System.out.println("🗑 삭제할 S3 파일 경로 (디코딩 적용): " + fileKey);
+
+            // S3에서 삭제
+            amazonS3Client.deleteObject(bucket, fileKey);
+        } catch (UnsupportedEncodingException e) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_URL);
+        }
+    }
+
+    // URL에서 파일 경로만 추출하는 메서드 추가
+    private String extractFileKeyFromUrl(String imageUrl) {
+        try {
+            URL url = new URL(imageUrl);
+            return url.getPath().substring(1); // '/' 제거한 경로 반환
+        } catch (MalformedURLException e) {
+            throw new GeneralException(ErrorStatus.INVALID_IMAGE_URL);
+        }
+    }
+
+
 }

--- a/src/main/java/com/cook/cookapp/ingredient/repository/IngredientRepository.java
+++ b/src/main/java/com/cook/cookapp/ingredient/repository/IngredientRepository.java
@@ -13,4 +13,5 @@ public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
     Page<Ingredient> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
     Page<Ingredient> findByUserIdOrderByUseByDateAsc(Long userId, Pageable pageable);
     Optional<Ingredient> findByIdAndUserId(Long ingredientId, Long userId);
+    Optional<Ingredient> findByFoodName(String name);
 }

--- a/src/main/java/com/cook/cookapp/recipe/controller/RecipeController.java
+++ b/src/main/java/com/cook/cookapp/recipe/controller/RecipeController.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 
 @RestController
 @RequestMapping("/api/recipe")
@@ -28,26 +30,42 @@ public class RecipeController {
     @Operation(summary = "레시피 저장 API", description = "My 레시피에 레시피를 저장합니다")
     @PostMapping("")
     public ApiResponse<String> storeRecipe(
-            @RequestBody  @Valid RecipeDtoReq.RecipeReq requestDto) {
+            @RequestBody RecipeDtoReq.StoreRecipeReq request) {
         Long userId = jwtTokenProvider.getUserIdFromToken();
-        recipeService.addRecipe(userId, requestDto);
+        recipeService.parseChatbotRecipe(userId, request);
         return ApiResponse.onSuccess("레시피 저장 완료");
+    }
+
+    @Operation(summary = "레시피 수정 API", description = "레시피를 수정합니다")
+    @PatchMapping("/{recipeId}")
+    public ApiResponse<String> updateRecipe(
+            @RequestBody  RecipeDtoReq.RecipeReq requestDto,
+            @PathVariable @Positive Long recipeId) {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        recipeService.updateRecipe(recipeId, userId, requestDto);
+        return ApiResponse.onSuccess("레시피 수정 완료");
+    }
+
+    @Operation(summary = "레시피 삭제 API", description = "레시피를 삭제합니다")
+    @DeleteMapping("/{recipeId}")
+    public ApiResponse<String> deleteRecipe(
+            @PathVariable @Positive Long recipeId) {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        recipeService.deleteRecipe(recipeId,userId);
+        return ApiResponse.onSuccess("레시피 삭제 완료");
     }
 
     @Operation(summary = "레시피 좋아요(toggle) API", description = "My 레시피에 좋아요를 누릅니다")
     @PatchMapping("/like/{recipeId}")
-    public ApiResponse<String> likeRecipe(@PathVariable Long recipeId) {
+    public ApiResponse<RecipeDtoRes.IsLikedRecipeRes> likeRecipe(@PathVariable @Positive Long recipeId) {
 
         Long userId = jwtTokenProvider.getUserIdFromToken();
-        boolean liked = recipeService.likeRecipe(userId, recipeId);
-        String message = liked ? "좋아요 등록" : "좋아요 취소";
-        return ApiResponse.onSuccess(message);
+        return ApiResponse.onSuccess(recipeService.likeRecipe(userId, recipeId));
     }
 
     @Operation(summary = "특정 레시피 조회 API", description = "특정 레시피를 조회합니다")
     @GetMapping("/{recipeId}")
-    public ApiResponse<RecipeDtoRes.UserRecipeRes> getRecipeById(@PathVariable Long recipeId) {
-        //TODO 제목,재료,instructions, 좋아요 여부,사진
+    public ApiResponse<RecipeDtoRes.UserRecipeRes> getRecipeById(@PathVariable @Positive Long recipeId) {
         Long userId = jwtTokenProvider.getUserIdFromToken();
         return ApiResponse.onSuccess(recipeService.getRecipeById(recipeId,userId));
     }
@@ -55,7 +73,7 @@ public class RecipeController {
 
     @Operation(summary = "My 레시피 조회 API", description = "My 레시피를 조회합니다")
     @GetMapping("")
-    public ApiResponse<Page<RecipeDtoRes.UserRecipeRes>> getRecipe(
+    public ApiResponse<Page<RecipeDtoRes.MyRecipeRes>> getRecipe(
             @RequestParam(defaultValue = "1") @Positive(message = "페이지 번호는 1 이상의 값이어야 합니다.")int page, // 기본값 1로 설정
             @PageableDefault(size = 10, sort = "isLiked", direction = Sort.Direction.DESC) Pageable pageable) {
 

--- a/src/main/java/com/cook/cookapp/recipe/converter/RecipeConverter.java
+++ b/src/main/java/com/cook/cookapp/recipe/converter/RecipeConverter.java
@@ -26,12 +26,11 @@ public class RecipeConverter {
 
     }
 
-    public RecipeDtoRes.UserRecipeRes toDto(Recipe recipe) {
-        return RecipeDtoRes.UserRecipeRes.builder()
+    public RecipeDtoRes.MyRecipeRes toDto(Recipe recipe) {
+        return RecipeDtoRes.MyRecipeRes.builder()
                 .id(recipe.getId())
                 .title(recipe.getTitle())
                 .isLiked(recipe.isLiked())
-                .instructions(recipe.getInstructions())
                 .build();
     }
 }

--- a/src/main/java/com/cook/cookapp/recipe/dto/req/RecipeDtoReq.java
+++ b/src/main/java/com/cook/cookapp/recipe/dto/req/RecipeDtoReq.java
@@ -13,13 +13,20 @@ public class RecipeDtoReq {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RecipeReq {
-        //TODO 사진도 넣어야 함.
 
-        @NotBlank(message = "레시피 이름은 필수입니다.")
         private String title;
 
-        @NotBlank(message = "레시피 방법은 필수입니다.")
+        private List<String> ingredients;
+
         private String instructions;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StoreRecipeReq {
+
+        private String recipe;
     }
 
 

--- a/src/main/java/com/cook/cookapp/recipe/dto/res/RecipeDtoRes.java
+++ b/src/main/java/com/cook/cookapp/recipe/dto/res/RecipeDtoRes.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 
+import java.util.List;
+
 @Getter
 @Builder
 public class RecipeDtoRes {
@@ -17,6 +19,28 @@ public class RecipeDtoRes {
         private String title;
         private boolean isLiked;
         private String instructions;
+        private List<String> ingredients;
+        private String imageUrl;
     }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class MyRecipeRes {
+        private Long id;
+        private String title;
+        private boolean isLiked;
+        private String imageUrl;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class IsLikedRecipeRes {
+        private boolean isLiked;
+    }
+
+
+
 }
 

--- a/src/main/java/com/cook/cookapp/recipe/entity/Recipe.java
+++ b/src/main/java/com/cook/cookapp/recipe/entity/Recipe.java
@@ -1,6 +1,7 @@
 package com.cook.cookapp.recipe.entity;
 
 import com.cook.cookapp.global.BaseEntity;
+import com.cook.cookapp.recipe.dto.req.RecipeDtoReq;
 import com.cook.cookapp.user.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -34,12 +35,19 @@ public class Recipe extends BaseEntity {
     private String instructions;
 
     //재료들
-    @OneToMany(mappedBy = "recipe", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @OneToMany(mappedBy = "recipe", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RecipeIngredient> recipeIngredients = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @JoinColumn(name = "recipeImage_id")
+    private RecipeImage recipeImage;
 
+    public void update(RecipeDtoReq.RecipeReq recipeReq) {
+        this.title = recipeReq.getTitle();
+        this.instructions = recipeReq.getInstructions();
+    }
 }

--- a/src/main/java/com/cook/cookapp/recipe/entity/RecipeImage.java
+++ b/src/main/java/com/cook/cookapp/recipe/entity/RecipeImage.java
@@ -1,0 +1,35 @@
+package com.cook.cookapp.recipe.entity;
+
+
+import com.cook.cookapp.global.BaseEntity;
+import com.cook.cookapp.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RecipeImage extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String uuid;
+
+    @Column(nullable = false)
+    private String originalFilename;
+
+    @Column
+    private String contentType;
+
+    @Column
+    private Long fileSize;
+
+    @OneToOne(mappedBy = "recipeImage")
+    private Recipe recipe;
+
+}

--- a/src/main/java/com/cook/cookapp/recipe/repository/RecipeImageRepository.java
+++ b/src/main/java/com/cook/cookapp/recipe/repository/RecipeImageRepository.java
@@ -1,0 +1,10 @@
+package com.cook.cookapp.recipe.repository;
+
+import com.cook.cookapp.recipe.entity.Recipe;
+import com.cook.cookapp.recipe.entity.RecipeImage;
+import com.cook.cookapp.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeImageRepository extends JpaRepository<RecipeImage, Long> {
+    RecipeImage findByRecipe(Recipe recipe);
+}

--- a/src/main/java/com/cook/cookapp/recipe/repository/RecipeIngredientRepository.java
+++ b/src/main/java/com/cook/cookapp/recipe/repository/RecipeIngredientRepository.java
@@ -1,0 +1,9 @@
+package com.cook.cookapp.recipe.repository;
+
+import com.cook.cookapp.recipe.entity.RecipeIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredient, Long> {
+}

--- a/src/main/java/com/cook/cookapp/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/cook/cookapp/recipe/repository/RecipeRepository.java
@@ -12,6 +12,6 @@ import java.util.Optional;
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     Recipe save(Recipe recipe);
     Page<Recipe> findByUserId(Long userId, Pageable pageable);
-
+    Recipe findByUserId(Long userId);
     Optional<Recipe> findByIdAndUserId(Long recipeId, Long userId);
 }

--- a/src/main/java/com/cook/cookapp/recipe/service/RecipeService.java
+++ b/src/main/java/com/cook/cookapp/recipe/service/RecipeService.java
@@ -3,13 +3,15 @@ package com.cook.cookapp.recipe.service;
 import com.cook.cookapp.recipe.dto.req.RecipeDtoReq;
 import com.cook.cookapp.recipe.dto.res.RecipeDtoRes;
 import com.cook.cookapp.recipe.entity.Recipe;
+import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface RecipeService {
-    Page<RecipeDtoRes.UserRecipeRes> findAll(Pageable pageable);
-    Page<RecipeDtoRes.UserRecipeRes> findByUserId(Long userId, Pageable pageable);
-    void addRecipe(Long userId, RecipeDtoReq.RecipeReq requestDto);
-    boolean likeRecipe(Long userId, Long recipeId);
+    Page<RecipeDtoRes.MyRecipeRes> findByUserId(Long userId, Pageable pageable);
+    RecipeDtoRes.IsLikedRecipeRes likeRecipe(Long userId, Long recipeId);
     RecipeDtoRes.UserRecipeRes getRecipeById(Long userId,Long recipeId);
+    void parseChatbotRecipe(Long userId,RecipeDtoReq.StoreRecipeReq request);
+    void updateRecipe(Long recipeId, Long userId, RecipeDtoReq.RecipeReq requestDto);
+    void deleteRecipe(Long recipeId,Long userId);
 }

--- a/src/main/java/com/cook/cookapp/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/recipe/service/RecipeServiceImpl.java
@@ -2,12 +2,17 @@ package com.cook.cookapp.recipe.service;
 
 import com.cook.cookapp.apiPayload.code.exception.GeneralException;
 import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
+import com.cook.cookapp.global.util.AmazonS3Util;
+import com.cook.cookapp.ingredient.entity.Ingredient;
+import com.cook.cookapp.ingredient.repository.IngredientRepository;
 import com.cook.cookapp.recipe.converter.RecipeConverter;
 import com.cook.cookapp.recipe.dto.req.RecipeDtoReq;
 import com.cook.cookapp.recipe.dto.res.RecipeDtoRes;
 import com.cook.cookapp.recipe.entity.Recipe;
 import com.cook.cookapp.recipe.entity.RecipeIngredient;
+import com.cook.cookapp.recipe.repository.RecipeIngredientRepository;
 import com.cook.cookapp.recipe.repository.RecipeRepository;
+import com.cook.cookapp.user.dto.req.UserDtoReq;
 import com.cook.cookapp.user.entity.User;
 import com.cook.cookapp.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +21,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,36 +35,102 @@ public class RecipeServiceImpl implements RecipeService {
     private final RecipeRepository recipeRepository;
     private final UserRepository userRepository;
     private final RecipeConverter recipeConverter;
+    private final AmazonS3Util amazonS3Util;
+    private final IngredientRepository ingredientRepository;
+    private final RecipeIngredientRepository recipeIngredientRepository;
 
     @Override
-    public Page<RecipeDtoRes.UserRecipeRes> findAll(Pageable pageable) {
-        return recipeRepository.findAll(pageable).map(recipeConverter::toDto);
+    public Page<RecipeDtoRes.MyRecipeRes> findByUserId(Long userId, Pageable pageable) {
+        Page<Recipe> recipes = recipeRepository.findByUserId(userId, pageable);
+
+        return recipes.map(recipe -> {
+            Long recipeId = recipe.getId();
+            String imageUrl = amazonS3Util.getRecipePath(recipeId);
+
+            RecipeDtoRes.MyRecipeRes userRecipeRes = recipeConverter.toDto(recipe);
+            userRecipeRes.setImageUrl(imageUrl);
+
+            return userRecipeRes;
+        });
     }
 
-    @Override
-    public Page<RecipeDtoRes.UserRecipeRes> findByUserId(Long userId, Pageable pageable) {
-        return recipeRepository.findByUserId(userId, pageable)
-                .map(recipeConverter::toDto); // ✅ 내 레시피만 조회
+    public void parseChatbotRecipe(Long userId, RecipeDtoReq.StoreRecipeReq request) {
+        try {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+            String[] sections = request.getRecipe().split("\n");
+
+            if (sections.length < 3) {
+                throw new GeneralException(ErrorStatus.INVALID_RECIPE_FORMAT);
+            }
+
+            String title = sections[0].replaceAll("[\\[\\]]", "").trim();
+
+            List<String> ingredientNames = new ArrayList<>();
+            String ingredientLine = sections[1].replace("[재료]", "").trim();
+            String[] ingredientParts = ingredientLine.split("[,\\n-]+");
+
+            for (String ingredient : ingredientParts) {
+                String cleanedIngredient = ingredient.trim();
+                if (!cleanedIngredient.isEmpty()) {
+                    ingredientNames.add(cleanedIngredient);
+                }
+            }
+
+            StringBuilder instructions = new StringBuilder();
+            String recipeText = sections[2].replace("[레시피]", "").trim();
+
+            Pattern pattern = Pattern.compile("(\\d+\\.\\s*)(.*)");
+            Matcher matcher = pattern.matcher(recipeText);
+
+            while (matcher.find()) {
+                instructions.append(matcher.group(1)) // 🔥 숫자 유지 (ex: "1. ")
+                        .append(matcher.group(2).trim()) // 🔥 단계 내용 추가
+                        .append("\n");
+            }
+
+            String instructionsText = instructions.toString().trim();
+            if (instructionsText.isEmpty()) {
+                throw new GeneralException(ErrorStatus.INVALID_RECIPE_FORMAT);
+            }
+
+            Recipe recipe = Recipe.builder()
+                    .title(title)
+                    .instructions(instructionsText)
+                    .user(user)
+                    .build();
+
+            recipeRepository.save(recipe);
+
+            List<RecipeIngredient> recipeIngredients = ingredientNames.stream()
+                    .map(name -> {
+                        Ingredient ingredient = ingredientRepository.findByFoodName(name)
+                                .orElseGet(() -> {
+                                    Ingredient newIngredient = new Ingredient();
+                                    newIngredient.setFoodName(name);
+                                    return ingredientRepository.save(newIngredient);
+                                });
+                        return new RecipeIngredient(null, recipe, ingredient); // ❌ ID를 직접 설정하지 않음
+                    })
+                    .collect(Collectors.toList());
+
+            recipe.setRecipeIngredients(recipeIngredients);
+            recipeRepository.save(recipe);
+            recipeIngredientRepository.saveAll(recipeIngredients);
+
+
+        } catch (GeneralException e) {
+            throw e; // 미리 정의된 예외는 그대로 던짐
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new GeneralException(ErrorStatus.FAIL_OOOOO); // 명확한 에러 메시지 제공
+        }
     }
 
-    public void addRecipe(Long userId, RecipeDtoReq.RecipeReq requestDto){
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        Recipe recipe = recipeConverter.toEntity(requestDto, user);
 
-        List<RecipeIngredient> recipeIngredients = user.getIngredientList().stream()
-                .map(ingredient -> RecipeIngredient.builder()
-                        .recipe(recipe)
-                        .ingredient(ingredient)
-                        .build())
-                .collect(Collectors.toList());
-
-        recipe.setRecipeIngredients(recipeIngredients);
-        recipeRepository.save(recipe);
-    }
-
-    public boolean likeRecipe(Long userId, Long recipeId) {
+    public RecipeDtoRes.IsLikedRecipeRes likeRecipe(Long userId, Long recipeId) {
         Recipe recipe = recipeRepository.findById(recipeId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
 
@@ -66,13 +141,78 @@ public class RecipeServiceImpl implements RecipeService {
 
         // 좋아요 상태 토글
         recipe.setLiked(!recipe.isLiked());
-        return recipe.isLiked();
+
+        return RecipeDtoRes.IsLikedRecipeRes.builder()
+                .isLiked(recipe.isLiked())
+                .build();
     }
 
     public RecipeDtoRes.UserRecipeRes getRecipeById(Long recipeId,Long userId){
         Recipe recipe = recipeRepository.findByIdAndUserId(recipeId, userId).orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
-        return recipeConverter.toDto(recipe);
+        String imageUrl = amazonS3Util.getRecipePath(recipeId);
+
+        List<String> ingredients = recipe.getRecipeIngredients()
+                .stream()
+                .map(ri -> ri.getIngredient().getFoodName())
+                .collect(Collectors.toList());
+
+        return RecipeDtoRes.UserRecipeRes.builder()
+                .id(recipeId)
+                .title(recipe.getTitle())
+                .imageUrl(imageUrl)
+                .ingredients(ingredients)
+                .instructions(recipe.getInstructions())
+                .isLiked(recipe.isLiked())
+                .build();
     }
 
+    public void updateRecipe(Long recipeId, Long userId, RecipeDtoReq.RecipeReq requestDto) {
+        Recipe recipe = recipeRepository.findByIdAndUserId(recipeId, userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
+        recipe.update(requestDto);
+        recipe.getRecipeIngredients().clear();
+        List<RecipeIngredient> currentIngredients = recipe.getRecipeIngredients();
+        Set<String> existingIngredientNames = currentIngredients.stream()
+                .map(ri -> ri.getIngredient().getFoodName())
+                .collect(Collectors.toSet());
+
+        for (String name : requestDto.getIngredients()) {
+            if (!existingIngredientNames.contains(name)) { // 기존에 없는 재료만 추가
+                Ingredient ingredient = ingredientRepository.findByFoodName(name)
+                        .orElseGet(() -> {
+                            Ingredient newIngredient = new Ingredient();
+                            newIngredient.setFoodName(name);
+                            return ingredientRepository.save(newIngredient);
+                        });
+
+                RecipeIngredient recipeIngredient = new RecipeIngredient(null, recipe, ingredient);
+                currentIngredients.add(recipeIngredient);
+            }
+        }
+
+
+        recipeRepository.save(recipe);
+        recipeIngredientRepository.saveAll(currentIngredients);
+
+    }
+
+
+    @Override
+    public void deleteRecipe(Long recipeId, Long userId) {
+        // 1. 레시피 정보 조회 (삭제할 이미지 URL 가져오기)
+        Recipe recipe = recipeRepository.findByIdAndUserId(recipeId, userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.RECIPE_NOT_FOUND));
+
+        String imageUrl = amazonS3Util.getRecipePath(recipeId);
+        System.out.println("🔍 삭제할 이미지 URL: " + imageUrl);
+
+        // 2. S3에서 이미지 삭제
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            amazonS3Util.deleteRecipeImage(imageUrl);
+        }
+
+        // 3. 레시피 삭제
+        recipeRepository.delete(recipe);
+    }
 
 }

--- a/src/main/java/com/cook/cookapp/user/controller/S3Controller.java
+++ b/src/main/java/com/cook/cookapp/user/controller/S3Controller.java
@@ -6,10 +6,7 @@ import com.cook.cookapp.global.util.AmazonS3Util;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -28,6 +25,16 @@ public class S3Controller {
         Long userId = jwtTokenProvider.getUserIdFromToken();
 
         String imageUrl = amazonS3Util.profileImageUpload(profileImage, userId);
+
+        return ApiResponse.onSuccess(imageUrl);
+    }
+
+    @Operation(summary = "레시피 이미지 업로드 API", description = "레시피 이미지를 업로드 합니다.")
+    @PostMapping(value = "/update-recipe/{recipeId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<String> updateRecipeImage(@RequestPart("recipeImage") MultipartFile recipeImage, @RequestParam Long recipeId) throws IOException {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+
+        String imageUrl = amazonS3Util.recipeImageUpload(recipeImage, recipeId, userId);
 
         return ApiResponse.onSuccess(imageUrl);
     }

--- a/src/main/resources/application-deploy.yml
+++ b/src/main/resources/application-deploy.yml
@@ -50,7 +50,7 @@ cloud:
       path:
         profile: profile
       #        post: post
-      #        recipe: recipe
+        recipe: recipe
       bucket: ${AWS_S3_BUCKET}
     region:
       static: ap-northeast-2

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -55,7 +55,7 @@ cloud:
       path:
         profile: profile
 #        post: post
-#        recipe: recipe
+        recipe: recipe
       bucket: ${AWS_S3_BUCKET}
     region:
       static: ap-northeast-2


### PR DESCRIPTION
## 🔍 이슈 번호

## ✨ PR 요약

- [x] 레시피 삭제 API 구현
- [x] 레시피 이미지 업로드 API 구현
- [x] 레시피 수정 API 구현
- [x] 레시피 저장 API 수정
- [x] 레시피 좋아요 API 수정
---
## 🛠 상세 설명
- [x] 레시피 삭제 API 구현 삭제 시 s3 이미지도 같이 삭제되게 구현
- [x] 레시피 이미지 s3에 업로드 기능 구현
- [x] 레시피 수정할 수 있도록 기능 구현
- [x] 기존 레시피 저장은 사용자가 직접 만든 레시피 저장 -> 수정 후 레시피 저장은 챗봇에게 받은 레시피 형식을 parsing하여 저장
- [x] 기존 레시피 좋아요 API에서 좋아요 여부를 보내지 않아 보내도록 수정 

---