### PR TITLE
:hammer: Ref[#136] 상세 게시글 조회 postImage 반환 방식 수정

### DIFF
--- a/src/main/java/com/cook/cookapp/post/converter/PostConverter.java
+++ b/src/main/java/com/cook/cookapp/post/converter/PostConverter.java
@@ -4,12 +4,15 @@ import com.cook.cookapp.global.util.AmazonS3Util;
 import com.cook.cookapp.post.dto.req.PostDtoReq;
 import com.cook.cookapp.post.dto.res.PostResDto;
 import com.cook.cookapp.post.entity.Post;
+import com.cook.cookapp.post.entity.PostImage;
 import com.cook.cookapp.post.repository.LikedPostRepository;
 import com.cook.cookapp.user.entity.User;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Component
@@ -52,8 +55,20 @@ public class PostConverter {
     }
 
     public PostResDto.SpecPostRes toSpecDto(Post post, Long userId) {
-        boolean isLiked = likedPostRepository.existsByUserIdAndPostId(userId,post.getId());
-        PostResDto.SpecPostRes specPostRes = PostResDto.SpecPostRes.builder()
+        boolean isLiked = likedPostRepository.existsByUserIdAndPostId(userId, post.getId());
+
+        List<String> imageUrls = amazonS3Util.getPostPath(post.getId());
+        List<PostImage> postImages = post.getPostImage();
+
+        List<PostResDto.SpecPostImageRes> imageList = new ArrayList<>();
+        for (int i = 0; i < postImages.size(); i++) {
+            imageList.add(PostResDto.SpecPostImageRes.builder()
+                    .imageId(postImages.get(i).getId())
+                    .imageUrl(imageUrls.get(i))
+                    .build());
+        }
+
+        return PostResDto.SpecPostRes.builder()
                 .id(post.getId())
                 .nickname(post.getUser().getNickname())
                 .district(post.getUser().getDistrict())
@@ -66,13 +81,12 @@ public class PostConverter {
                 .timeAgo(calTime(post.getUpdatedAt()))
                 .liked(isLiked)
                 .likeCount(post.getLikeCount())
-                .imageIds(post.getPostImage().stream().map(postImage -> postImage.getId()).collect(Collectors.toList()))
+                .image(imageList)
+                .profileImageUrl(amazonS3Util.getProfilePath(post.getUser().getId()))
                 .build();
-        specPostRes.setImageUrls(amazonS3Util.getPostPath(post.getId()));
-        specPostRes.setProfileImageUrl(amazonS3Util.getProfilePath(post.getUser().getId()));
-        //TODO 등급 설정, 조회수
-        return specPostRes;
     }
+
+
 
     public static String calTime(LocalDateTime updatedAt) {
         LocalDateTime now = LocalDateTime.now();

--- a/src/main/java/com/cook/cookapp/post/dto/res/PostResDto.java
+++ b/src/main/java/com/cook/cookapp/post/dto/res/PostResDto.java
@@ -48,10 +48,18 @@ public class PostResDto {
         private String district;
         private String neighborhood;
         private boolean liked;
-        private List<String> imageUrls;
-        private List<Long> imageIds;
+        private List<SpecPostImageRes> image;
         private String profileImageUrl;
     }
+
+    @Data
+    @AllArgsConstructor
+    @Builder
+    public static class SpecPostImageRes{
+        private String imageUrl;
+        private Long imageId;
+    }
+
 
     @Data
     @AllArgsConstructor


### PR DESCRIPTION
## 🔍 이슈 번호
[#136 ]

## ✨ PR 요약
- [x] 상세 게시글 조회 postImage 반환 방식 수정

---
## 🛠 상세 설명
- [x] 기존 방식은 배열의 인덱싱에 의존해서 각 배열의 원소 수가 달라지면 오류 발생 위험이 있어 dto 만들어 id,url 묶어서 한 번에 반환

---