### PR TITLE
:sparkles:feat[#198] FCM 식재료 소비기한 예약 알림 구현

### DIFF
--- a/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/cook/cookapp/apiPayload/code/status/ErrorStatus.java
@@ -86,7 +86,16 @@ public enum ErrorStatus implements BaseErrorCode {
     CHATROOM_FULL(HttpStatus.BAD_REQUEST, "CHAT4003", "채팅방 인원이 가득 찼습니다."),
     NOT_PARTICIPANT_CHATROOM(HttpStatus.BAD_REQUEST, "CHAT4004", "채팅방에 참여 중이지 않습니다."),
     CHATROOM_CLOSED(HttpStatus.BAD_REQUEST, "CHAT4005", "채팅방이 마감되었습니다."),
-    CHATROOM_NOT_OWNER(HttpStatus.FORBIDDEN, "CHAT4006", "채팅방을 마감할 권한이 없습니다.");
+    CHATROOM_NOT_OWNER(HttpStatus.FORBIDDEN, "CHAT4006", "채팅방을 마감할 권한이 없습니다."),
+
+    //식재료 소비기한 알림
+    INVALID_NOTIFICATION_TIME(HttpStatus.BAD_REQUEST, "INGREDIENT4001", "소비기한 이전으로만 알림을 예약할 수 있습니다."),
+    NOTIFICATION_DISABLED(HttpStatus.BAD_REQUEST, "INGREDIENT4002", "알림이 꺼진 상태입니다."),
+    ALREADY_RESERVED(HttpStatus.BAD_REQUEST, "INGREDIENT4003", "이미 알림이 예약된 식재료입니다."),
+    NOTIFICATION_TIME_IN_PAST(HttpStatus.BAD_REQUEST, "INGREDIENT4004", "현재 시간보다 이전으로는 예약할 수 없습니다."),
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404", "해당 알림을 찾을 수 없습니다."),;
+
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/cook/cookapp/global/notification/services/FcmService.java
+++ b/src/main/java/com/cook/cookapp/global/notification/services/FcmService.java
@@ -29,4 +29,21 @@ public class FcmService {
             log.error("[FCM] 푸시 알림 전송 실패", e);
         }
     }
+
+    public void sendFcmIngredient(String targetToken, String title, String body) {
+        try {
+            Message message = Message.builder()
+                    .setToken(targetToken)
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .build();
+
+            FirebaseMessaging.getInstance().sendAsync(message);
+            log.info("[FCM] 식재료 소비기한 푸시 알림 전송 완료 - 대상: {}", targetToken);
+        } catch (Exception e) {
+            log.error("[FCM] 식재료 소비기한 푸시 알림 전송 실패", e);
+        }
+    }
 }

--- a/src/main/java/com/cook/cookapp/ingredient/controller/NotificationController.java
+++ b/src/main/java/com/cook/cookapp/ingredient/controller/NotificationController.java
@@ -1,0 +1,43 @@
+package com.cook.cookapp.ingredient.controller;
+
+import com.cook.cookapp.apiPayload.ApiResponse;
+import com.cook.cookapp.common.security.JwtTokenProvider;
+import com.cook.cookapp.ingredient.dto.res.IngredientNotificationDtoRes;
+import com.cook.cookapp.ingredient.service.IngredientNotificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final IngredientNotificationService ingredientNotificationService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Operation(summary = "소비기한 알림 목록 조회 API", description = "소비기한 임박 알림 목록을 조회합니다.")
+    @GetMapping("")
+    public ApiResponse<List<IngredientNotificationDtoRes>> getMyNotifications() {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        return ApiResponse.onSuccess(ingredientNotificationService.getMyNotifications(userId));
+    }
+
+    @Operation(summary = "해당 알림 읽음 처리 API", description = "입력한 id의 알알림을 읽음 처리 합니다.")
+    @PostMapping("/{id}/read")
+    public ApiResponse<String> markAsRead(@PathVariable Long id) {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        ingredientNotificationService.markAsRead(userId, id);
+        return ApiResponse.onSuccess("알림을 확인했습니다.");
+    }
+
+    @Operation(summary = "안읽은 알림수 조회 API", description = "사용자가 확인하지 않은 알림 수를 조회합니다.")
+    @GetMapping("/unread-count")
+    public ApiResponse<Long> getUnreadCount() {
+        Long userId = jwtTokenProvider.getUserIdFromToken();
+        return ApiResponse.onSuccess(ingredientNotificationService.countUnread(userId));
+    }
+}
+

--- a/src/main/java/com/cook/cookapp/ingredient/dto/res/IngredientDtoRes.java
+++ b/src/main/java/com/cook/cookapp/ingredient/dto/res/IngredientDtoRes.java
@@ -1,13 +1,7 @@
 package com.cook.cookapp.ingredient.dto.res;
 
-import com.cook.cookapp.ingredient.entity.Enum.AlarmStatus;
-import com.cook.cookapp.ingredient.entity.Enum.StorageType;
-import com.cook.cookapp.ingredient.entity.Ingredient;
 import lombok.Builder;
 import lombok.Getter;
-
-import java.time.LocalDate;
-import java.time.ZoneId;
 
 @Getter
 @Builder
@@ -19,18 +13,4 @@ public class IngredientDtoRes {
     private int count;
     private boolean storageType;
     private boolean alarmStatus;
-
-    public static IngredientDtoRes fromEntity(Ingredient ingredient) {
-        return IngredientDtoRes.builder()
-                .id(ingredient.getId())
-                .foodName(ingredient.getFoodName())
-                .useByDate(ingredient.getUseByDate()
-                        .atStartOfDay(ZoneId.systemDefault())
-                        .toInstant()
-                        .toEpochMilli())  // LocalDate → 밀리초(Long) 변환
-                .count(ingredient.getCount())
-                .storageType(ingredient.getStorageType() == StorageType.FROZEN)  // 냉장(false) → 냉동(true)
-                .alarmStatus(ingredient.getAlarmStatus() == AlarmStatus.ON)  // OFF(false), ON(true)
-                .build();
-    }
 }

--- a/src/main/java/com/cook/cookapp/ingredient/dto/res/IngredientNotificationDtoRes.java
+++ b/src/main/java/com/cook/cookapp/ingredient/dto/res/IngredientNotificationDtoRes.java
@@ -1,0 +1,17 @@
+package com.cook.cookapp.ingredient.dto.res;
+
+import com.cook.cookapp.ingredient.entity.Enum.NotificationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class IngredientNotificationDtoRes {
+    private Long id;
+    private String ingredientName;
+    private LocalDateTime scheduledAt;
+    private NotificationStatus status;
+    private boolean isRead;
+}

--- a/src/main/java/com/cook/cookapp/ingredient/entity/Enum/NotificationStatus.java
+++ b/src/main/java/com/cook/cookapp/ingredient/entity/Enum/NotificationStatus.java
@@ -1,0 +1,7 @@
+package com.cook.cookapp.ingredient.entity.Enum;
+
+public enum NotificationStatus {
+    PENDING,   // 아직 처리되지 않음
+    SENT,      // FCM 발송 완료
+    SKIPPED    // 알림 OFF 등으로 전송 생략
+}

--- a/src/main/java/com/cook/cookapp/ingredient/entity/Ingredient.java
+++ b/src/main/java/com/cook/cookapp/ingredient/entity/Ingredient.java
@@ -13,6 +13,8 @@ import lombok.*;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -41,6 +43,7 @@ public class Ingredient extends BaseEntity {
     private int count;
 
     //알림 상태 (ON,OFF) - 기본값 ON.
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AlarmStatus alarmStatus = AlarmStatus.ON;
@@ -50,6 +53,7 @@ public class Ingredient extends BaseEntity {
     private IngredientImage ingredientImage;
 
     // 저장 타입 (냉장, 냉동) - 기본값 냉장.
+    @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private StorageType storageType = StorageType.REFRIGERATED;
@@ -57,6 +61,9 @@ public class Ingredient extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
+
+    @OneToMany(mappedBy = "ingredient", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<IngredientNotification> notifications = new ArrayList<>();
 
     @PrePersist
     public void prePersist() {
@@ -77,5 +84,9 @@ public class Ingredient extends BaseEntity {
         this.count = ingredientDtoReq.getCount();
         this.storageType = ingredientDtoReq.isStorageType() ? StorageType.FROZEN : StorageType.REFRIGERATED;
         this.alarmStatus = ingredientDtoReq.isAlarmStatus() ? AlarmStatus.ON : AlarmStatus.OFF;
+    }
+
+    public boolean isNotificationEnabled() {
+        return this.alarmStatus == AlarmStatus.ON;
     }
 }

--- a/src/main/java/com/cook/cookapp/ingredient/entity/IngredientNotification.java
+++ b/src/main/java/com/cook/cookapp/ingredient/entity/IngredientNotification.java
@@ -1,0 +1,49 @@
+package com.cook.cookapp.ingredient.entity;
+
+import com.cook.cookapp.ingredient.entity.Enum.NotificationStatus;
+import com.cook.cookapp.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+import static com.cook.cookapp.ingredient.entity.Enum.NotificationStatus.PENDING;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Entity
+public class IngredientNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ingredient_id")
+    private Ingredient ingredient;
+
+    private LocalDateTime scheduledAt;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationStatus status = PENDING;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean isRead = false;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.status == null) {
+            this.status = PENDING;
+        }
+    }
+}

--- a/src/main/java/com/cook/cookapp/ingredient/repository/IngredientNotificationScheduleRepository.java
+++ b/src/main/java/com/cook/cookapp/ingredient/repository/IngredientNotificationScheduleRepository.java
@@ -1,0 +1,18 @@
+package com.cook.cookapp.ingredient.repository;
+
+import com.cook.cookapp.ingredient.entity.Enum.NotificationStatus;
+import com.cook.cookapp.ingredient.entity.Ingredient;
+import com.cook.cookapp.ingredient.entity.IngredientNotification;
+import com.cook.cookapp.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface IngredientNotificationScheduleRepository extends JpaRepository<IngredientNotification, Long> {
+    boolean existsByIngredientAndScheduledAt(Ingredient ingredient, LocalDateTime scheduledAt);
+    List<IngredientNotification> findByUserAndStatusOrderByScheduledAtDesc(User user, NotificationStatus status);
+    List<IngredientNotification> findByStatusAndScheduledAtBefore(NotificationStatus status, LocalDateTime before);
+    long countByUserIdAndIsReadFalseAndStatus(Long userId, NotificationStatus status);
+
+}

--- a/src/main/java/com/cook/cookapp/ingredient/service/IngredientNotificationService.java
+++ b/src/main/java/com/cook/cookapp/ingredient/service/IngredientNotificationService.java
@@ -1,0 +1,120 @@
+package com.cook.cookapp.ingredient.service;
+
+import com.cook.cookapp.apiPayload.code.exception.GeneralException;
+import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
+import com.cook.cookapp.global.notification.services.FcmService;
+import com.cook.cookapp.ingredient.dto.res.IngredientNotificationDtoRes;
+import com.cook.cookapp.ingredient.entity.Enum.NotificationStatus;
+import com.cook.cookapp.ingredient.entity.Ingredient;
+import com.cook.cookapp.ingredient.entity.IngredientNotification;
+import com.cook.cookapp.ingredient.repository.IngredientNotificationScheduleRepository;
+import com.cook.cookapp.ingredient.repository.IngredientRepository;
+import com.cook.cookapp.user.entity.User;
+import com.cook.cookapp.user.repository.UserRepository;
+import com.cook.cookapp.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class IngredientNotificationService {
+    private final IngredientNotificationScheduleRepository notificationRepository;
+    private final IngredientRepository ingredientRepository;
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final FcmService fcmService;
+
+    public void scheduleNotification(Long userId, Long ingredientId, LocalDateTime whenToNotify) {
+        var user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        var ingredient = ingredientRepository.findById(ingredientId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.INGREDIENT_NOT_FOUND));
+
+        if (!ingredient.isNotificationEnabled()) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_DISABLED);
+        }
+
+        if (whenToNotify.isAfter(ingredient.getUseByDate().atStartOfDay())) {
+            throw new GeneralException(ErrorStatus.INVALID_NOTIFICATION_TIME);
+        }
+
+        if (whenToNotify.isBefore(LocalDateTime.now())) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_TIME_IN_PAST);
+        }
+
+        boolean exists = notificationRepository.existsByIngredientAndScheduledAt(ingredient, whenToNotify);
+        if (exists) {
+            throw new GeneralException(ErrorStatus.ALREADY_RESERVED);
+        }
+
+        var schedule = IngredientNotification.builder()
+                .user(user)
+                .ingredient(ingredient)
+                .scheduledAt(whenToNotify)
+                .status(NotificationStatus.PENDING)
+                .build();
+
+        notificationRepository.save(schedule);
+    }
+
+
+    @Scheduled(fixedRate = 60000)
+    public void sendScheduledNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+        var schedules = notificationRepository.findByStatusAndScheduledAtBefore(NotificationStatus.PENDING, now);
+
+        for (var schedule : schedules) {
+            Ingredient ingredient = schedule.getIngredient();
+
+            if (!ingredient.isNotificationEnabled()) {
+                schedule.setStatus(NotificationStatus.SKIPPED);
+                continue;
+            }
+
+            String token = userService.getFcmToken(schedule.getUser().getId());
+            fcmService.sendFcmIngredient(token, "소비기한 알림", ingredient.getFoodName() + " 소비기한이 임박합니다!");
+            schedule.setStatus(NotificationStatus.SENT);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public List<IngredientNotificationDtoRes> getMyNotifications(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        List<IngredientNotification> list = notificationRepository.findByUserAndStatusOrderByScheduledAtDesc(user, NotificationStatus.SENT);
+
+        return list.stream().map(n -> IngredientNotificationDtoRes.builder()
+                .id(n.getId())
+                .ingredientName(n.getIngredient().getFoodName())
+                .scheduledAt(n.getScheduledAt())
+                .status(n.getStatus())
+                .isRead(n.isRead())
+                .build()
+        ).toList();
+    }
+
+    public void markAsRead(Long userId, Long notificationId) {
+        IngredientNotification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        if (!notification.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.UNAUTHORIZED_ACCESS);
+        }
+
+        notification.setRead(true);
+    }
+
+    @Transactional(readOnly = true)
+    public long countUnread(Long userId) {
+        return notificationRepository.countByUserIdAndIsReadFalseAndStatus(userId,  NotificationStatus.SENT);
+    }
+
+}

--- a/src/main/java/com/cook/cookapp/ingredient/service/IngredientServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/ingredient/service/IngredientServiceImpl.java
@@ -11,6 +11,7 @@ import com.cook.cookapp.ingredient.dto.res.IngredientDtoRes;
 import com.cook.cookapp.ingredient.entity.Enum.AlarmStatus;
 import com.cook.cookapp.ingredient.entity.Ingredient;
 import com.cook.cookapp.ingredient.repository.IngredientImageRepository;
+import com.cook.cookapp.ingredient.repository.IngredientNotificationScheduleRepository;
 import com.cook.cookapp.ingredient.repository.IngredientRepository;
 import com.cook.cookapp.user.entity.User;
 import com.cook.cookapp.user.repository.UserRepository;
@@ -22,6 +23,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @RequiredArgsConstructor
 @Service
@@ -33,6 +36,8 @@ public class IngredientServiceImpl implements IngredientService{
     private final IngredientConverter ingredientConverter;
     private final AmazonS3Util amazonS3Util;
     private final IngredientImageRepository ingredientImageRepository;
+    private final IngredientNotificationService ingredientNotificationService;
+    private final IngredientNotificationScheduleRepository scheduleRepository;
 
 
     @Override
@@ -48,6 +53,20 @@ public class IngredientServiceImpl implements IngredientService{
                 throw new GeneralException(ErrorStatus.INVALID_IMAGE_URL);
             }
         }
+        LocalDate useByDate = ingredient.getUseByDate();
+
+        LocalDateTime notify3DaysBefore = useByDate.minusDays(3).atStartOfDay();
+        LocalDateTime notify1DayBefore = useByDate.minusDays(1).atStartOfDay();
+
+        // 현재보다 미래인 경우에만 예약
+        if (notify3DaysBefore.isAfter(LocalDateTime.now())) {
+            ingredientNotificationService.scheduleNotification(userId, ingredient.getId(), notify3DaysBefore);
+        }
+
+        if (notify1DayBefore.isAfter(LocalDateTime.now())) {
+            ingredientNotificationService.scheduleNotification(userId, ingredient.getId(), notify1DayBefore);
+        }
+
     }
 
     @Override

--- a/src/main/java/com/cook/cookapp/user/service/UserService.java
+++ b/src/main/java/com/cook/cookapp/user/service/UserService.java
@@ -24,6 +24,6 @@ public interface UserService {
     void updateNickname(Long userId, String nickname);
     User getUserById(Long id);
     void updateFcmToken(Long userId, String token);
-
     void deleteUser(Long userId);
+    String getFcmToken(Long userId);
 }

--- a/src/main/java/com/cook/cookapp/user/service/UserServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/user/service/UserServiceImpl.java
@@ -5,16 +5,11 @@ import com.cook.cookapp.apiPayload.code.status.ErrorStatus;
 import com.cook.cookapp.chatbot.util.TastePreferenceValidator;
 import com.cook.cookapp.common.security.JwtTokenProvider;
 import com.cook.cookapp.global.util.AmazonS3Util;
-import com.cook.cookapp.ingredient.repository.IngredientRepository;
-import com.cook.cookapp.post.repository.PostRepository;
-import com.cook.cookapp.post.repository.SearchHistoryRepository;
-import com.cook.cookapp.recipe.repository.RecipeRepository;
 import com.cook.cookapp.user.converter.UserConverter;
 import com.cook.cookapp.user.dto.req.UserDtoReq;
 import com.cook.cookapp.user.dto.res.KakaoUserInfoResponseDto;
 import com.cook.cookapp.user.dto.res.UserDtoRes;
 import com.cook.cookapp.user.entity.User;
-import com.cook.cookapp.user.repository.ProfileImageRepository;
 import com.cook.cookapp.user.repository.ReportRepository;
 import com.cook.cookapp.user.repository.UserRepository;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,11 +31,6 @@ public class UserServiceImpl implements UserService {
     private static final Logger log = LoggerFactory.getLogger(UserService.class);
     private final AmazonS3Util amazonS3Util;
     private final ReportRepository reportRepository;
-    private final ProfileImageRepository profileImageRepository;
-    private final PostRepository postRepository;
-    private final RecipeRepository recipeRepository;
-    private final SearchHistoryRepository searchHistoryRepository;
-    private final IngredientRepository ingredientRepository;
 
     // 일반 로그인 처리: 이메일로 유저 찾고 토큰 발급
     public UserDtoRes.UserLoginRes login(HttpServletRequest request, HttpServletResponse response, UserDtoReq.LoginReq loginDto) {
@@ -208,5 +198,11 @@ public class UserServiceImpl implements UserService {
         userRepository.flush();
     }
 
+    @Override
+    public String getFcmToken(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+        return user.getFcmToken();
+    }
 
 }


### PR DESCRIPTION
## 🔍 이슈 번호
[#198]
## ✨ PR 요약
<!--변경 포인트-->
- 식재료 소비기한 예약 푸시 알림 구현
- 소비기한 알림 목록 조회 API 구현
- 알림 읽음 처리 API 구현
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 식재료 삭제 시 예약 알림 삭제
- 식재료 알림 OFF 처리 -> 다시 ON할 경우을 생각해서 삭제하지 않고, 푸시알림을 보내기 전에 알림 상태(ON/OFF)를 확인하는 방식으로 구현
---