### PR TITLE
:hammer: Ref[#204] 레시피 저장시 중복 저장 방지 로직 구현

### DIFF
--- a/src/main/java/com/cook/cookapp/recipe/entity/Recipe.java
+++ b/src/main/java/com/cook/cookapp/recipe/entity/Recipe.java
@@ -31,7 +31,7 @@ public class Recipe extends BaseEntity {
     private boolean isLiked = false;
 
     //레시피 방법
-    @Column(length = 500, unique = true)
+    @Column(length = 500)
     private String instructions;
 
     //재료들

--- a/src/main/java/com/cook/cookapp/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/cook/cookapp/recipe/repository/RecipeRepository.java
@@ -14,4 +14,5 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     Page<Recipe> findByUserId(Long userId, Pageable pageable);
     Recipe findByUserId(Long userId);
     Optional<Recipe> findByIdAndUserId(Long recipeId, Long userId);
+    Optional<Recipe> findByUserIdAndTitleAndInstructions(Long userId, String title, String instructionsText);
 }

--- a/src/main/java/com/cook/cookapp/recipe/service/RecipeServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/recipe/service/RecipeServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -93,6 +94,12 @@ public class RecipeServiceImpl implements RecipeService {
             String instructionsText = instructions.toString().trim();
             if (instructionsText.isEmpty()) {
                 throw new GeneralException(ErrorStatus.INVALID_RECIPE_FORMAT);
+            }
+
+            Optional<Recipe> userRecipe = recipeRepository.findByUserIdAndTitleAndInstructions(userId, title, instructionsText);
+
+            if(userRecipe.isPresent()) {
+                throw new GeneralException(ErrorStatus.DUPLICATE_RECIPE);
             }
 
             Recipe recipe = Recipe.builder()


### PR DESCRIPTION
## 🔍 이슈 번호
[#204]
## ✨ PR 요약
<!--변경 포인트-->
- RecipeServiceImpl에서 parseChatbotRecipe 함수에서 중복 저장 방지 로직 구현
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 챗봇이 만들어 준 같은 레시피를 다른 사용자가 저장할 때 중복 저장됐다고 뜸 -> Recipe에서 instructions unique=false로 수정
- 레시피 저장 버튼을 누를 때 여러 번 누르면 이미 저장된 레시피라고 에러 처리

---