### PR TITLE
:hammer:ref [#198] 채팅방 참여자 조회 정보 수정

### DIFF
--- a/src/main/java/com/cook/cookapp/chat/dto/res/ChatDtoRes.java
+++ b/src/main/java/com/cook/cookapp/chat/dto/res/ChatDtoRes.java
@@ -63,6 +63,7 @@ public class ChatDtoRes {
     @Getter
     @AllArgsConstructor(staticName = "of")
     public static class ChatRoomMemberListResponse {
+        private Long userId;
         private String nickname;
         private String imageUrl; // 프로필 이미지 URL
         private boolean isHost; // 방장 여부

--- a/src/main/java/com/cook/cookapp/chat/service/ChatServiceImpl.java
+++ b/src/main/java/com/cook/cookapp/chat/service/ChatServiceImpl.java
@@ -423,7 +423,7 @@ public class ChatServiceImpl implements ChatService {
                 .map(user -> {
                     String imageUrl = amazonS3Util.getProfilePath(user.getId()); // S3 경로 가져오기
                     boolean isHost = user.getId().equals(room.getHostUserId());
-                    return ChatDtoRes.ChatRoomMemberListResponse.of(user.getNickname(), imageUrl, isHost);
+                    return ChatDtoRes.ChatRoomMemberListResponse.of(user.getId(),user.getNickname(), imageUrl, isHost);
                 })
                 .toList();
     }


### PR DESCRIPTION
## 🔍 이슈 번호
[#198]
## ✨ PR 요약
<!--변경 포인트-->
- 채팅방 참여자 조회 res에 userId 추가
---
## 🛠 상세 설명
<!-- 변경 포인트 상세 설명-->
- 사용자가 닉네임을 수정하면, 채팅방에 닉네임이 수정이 안되는 버그 발생 -> 채팅방 참여자 조회 API에서 직접 user닉네임을 가져 오도록 수정

---